### PR TITLE
Properly escape data for injection into HTML

### DIFF
--- a/lib/rspec-view.coffee
+++ b/lib/rspec-view.coffee
@@ -83,10 +83,10 @@ class RSpecView extends ScrollView
   addOutput: (output) =>
 
     output = "#{output}"
-    output = output.replace /([^\s]*:[0-9]+)/g, (match) ->
+    output = output.replace /([^\s]*:[0-9]+)/g, (match) =>
       file = match.split(":")[0]
       line = match.split(":")[1]
-      "<a href='#{file}' data-line='#{line}' data-file='#{file}'>#{match}</a>"
+      $$$ -> @a href: file, 'data-line': line, 'data-file': file, match
 
     @spinner.hide()
     @output.append("#{output}")


### PR DESCRIPTION
My debug output was getting interpreted as HTML. No good. This fixes it so that what you see is always what you echoed.
