### PR TITLE
Fix UI for setting keymaps

### DIFF
--- a/keymaps/rspec.cson
+++ b/keymaps/rspec.cson
@@ -8,6 +8,6 @@
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
 '.editor':
-  'ctrl+alt+t': 'rspec:run'
-  'ctrl+alt+x': 'rspec:run-for-line'
-  'ctrl+alt+e': 'rspec:run-last'
+  'ctrl+alt+t': 'atom-rspec:run'
+  'ctrl+alt+x': 'atom-rspec:run-for-line'
+  'ctrl+alt+e': 'atom-rspec:run-last'

--- a/lib/rspec.coffee
+++ b/lib/rspec.coffee
@@ -14,9 +14,9 @@ module.exports =
     atom.config.setDefaults "atom-rspec",
       command: "rspec"
 
-    atom.workspaceView.command 'rspec:run'         , => @run()
-    atom.workspaceView.command 'rspec:run-for-line', => @runForLine()
-    atom.workspaceView.command 'rspec:run-last'    , => @runLast()
+    atom.workspaceView.command 'atom-rspec:run'         , => @run()
+    atom.workspaceView.command 'atom-rspec:run-for-line', => @runForLine()
+    atom.workspaceView.command 'atom-rspec:run-last'    , => @runLast()
 
     atom.workspace.registerOpener (uriToOpen) ->
       {protocol, pathname} = url.parse(uriToOpen)

--- a/menus/rspec.cson
+++ b/menus/rspec.cson
@@ -1,9 +1,9 @@
 # See https://atom.io/docs/latest/creating-a-package#menus for more details
 'context-menu':
   '.overlayer':
-      'Run All Specs': 'rspec:run'
-      'Run Current Spec': 'rspec:run-for-line'
-      'Re-Run Last Spec': 'rspec:run-last'
+      'Run All Specs': 'atom-rspec:run'
+      'Run Current Spec': 'atom-rspec:run-for-line'
+      'Re-Run Last Spec': 'atom-rspec:run-last'
 
 'menu': [
   {
@@ -11,9 +11,9 @@
     'submenu': [
       'label': 'RSpec'
       'submenu': [
-        { 'label': 'Run All Specs', 'command': 'rspec:run' }
-        { 'label': 'Run Current Spec', 'command': 'rspec:run-for-line' }
-        { 'label': 'Re-Run Last Spec', 'command': 'rspec:run-last' }
+        { 'label': 'Run All Specs', 'command': 'atom-rspec:run' }
+        { 'label': 'Run Current Spec', 'command': 'atom-rspec:run-for-line' }
+        { 'label': 'Re-Run Last Spec', 'command': 'atom-rspec:run-last' }
       ]
     ]
   }

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "private": true,
   "description": "Atom RSpec runner package",
   "activationEvents": [
-    "rspec:run",
-    "rspec:run-for-line",
-    "rspec:run-last"
+    "atom-rspec:run",
+    "atom-rspec:run-for-line",
+    "atom-rspec:run-last"
   ],
   "repository": "https://github.com/fcoury/atom-rspec",
   "license": "MIT",


### PR DESCRIPTION
The Key Map Settings UI was not being displayed. This PR changes names of all three commands, so that "atom-" is prepended to each command, so that the Settings UI recognizes them.
