### PR TITLE
Save all before running specs

### DIFF
--- a/lib/rspec.coffee
+++ b/lib/rspec.coffee
@@ -46,6 +46,7 @@ module.exports =
 
   runForLine: ->
     console.log "Starting runForLine..."
+    atom.workspace.saveAll()
     editor = atom.workspace.getActiveEditor()
     console.log "Editor", editor
     return unless editor?
@@ -59,10 +60,12 @@ module.exports =
 
   runLast: ->
     return unless @lastFile?
+    atom.workspace.saveAll()
     @openUriFor(@lastFile, @lastLine)
 
   run: ->
     console.log "RUN"
+    atom.workspace.saveAll()
     editor = atom.workspace.getActiveEditor()
     return unless editor?
 


### PR DESCRIPTION
Please let me know if there's anything you'd like changed about this. For example, it could be configurable via a checkbox.

I ignored tests since I wasn't able to get the tests to pass, before or after making this change. I ran the tests with ctrl-opt-cmd-P as described [here](https://atom.io/docs/v0.83.0/creating-a-package).