### PR TITLE
ctrl+alt+r to run all specs

### DIFF
--- a/keymaps/rspec.cson
+++ b/keymaps/rspec.cson
@@ -11,3 +11,4 @@
   'ctrl+alt+t': 'rspec:run'
   'ctrl+alt+x': 'rspec:run-for-line'
   'ctrl+alt+e': 'rspec:run-last'
+  'ctrl+alt+r': 'rspec:run-all'

--- a/lib/rspec.coffee
+++ b/lib/rspec.coffee
@@ -4,7 +4,8 @@ RSpecView = require './rspec-view'
 
 module.exports =
   configDefaults:
-    command: "rspec"
+    command: "rspec",
+    spec_directory: "spec"
 
   activate: (state) ->
     if state?
@@ -17,6 +18,7 @@ module.exports =
     atom.workspaceView.command 'rspec:run'         , => @run()
     atom.workspaceView.command 'rspec:run-for-line', => @runForLine()
     atom.workspaceView.command 'rspec:run-last'    , => @runLast()
+    atom.workspaceView.command 'rspec:run-all'     , => @runAll()
 
     atom.workspace.registerOpener (uriToOpen) ->
       {protocol, pathname} = url.parse(uriToOpen)
@@ -67,3 +69,9 @@ module.exports =
     return unless editor?
 
     @openUriFor(editor.getPath())
+
+  runAll: ->
+    project = atom.project
+    return unless project?
+
+    @openUriFor(project.getPath() + "/" + atom.config.get("rspec.spec_directory"))

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "activationEvents": [
     "rspec:run",
     "rspec:run-for-line",
-    "rspec:run-last"
+    "rspec:run-last",
+    "rspec:run-all"
   ],
   "repository": "https://github.com/fcoury/atom-rspec",
   "license": "MIT",


### PR DESCRIPTION
I don't know if this is the way forward for all users, but I really wanted to be able to run a whole project's worth of specs on occasion, and that meant knowing what directory specs were in. 

I added a configDefault for that.

I mostly wanted to make a feature request, and I already had the code, so...
