### PR TITLE
Use the right line number.

### DIFF
--- a/lib/rspec.coffee
+++ b/lib/rspec.coffee
@@ -52,7 +52,7 @@ module.exports =
 
     cursor = editor.getCursor()
     console.log "Cursor", cursor
-    line = cursor.getScreenRow()
+    line = cursor.getBufferRow() + 1
     console.log "Line", line
 
     @openUriFor(editor.getPath(), line)


### PR DESCRIPTION
The current implementation doesn't work if you fold some blocks before the line you want to run.

`getScreenRow()` ignores fold, `getBufferRow()` doesn't.
