### PR TITLE
Do not replace default editor style with rspec

### DIFF
--- a/stylesheets/rspec.less
+++ b/stylesheets/rspec.less
@@ -15,13 +15,13 @@
   text-align: center;
 }
 
-.rspec {
+.rspec:not(.editor) {
   background-color: black;
   color: white;
   overflow: scroll;
 }
 
-.rspec {
+.rspec:not(.editor) {
   pre,
   pre div.editor,
   code,


### PR DESCRIPTION
This is fix for issue #17. 
When using shortcut, rspec replaces line color and background color. This pull request should fix this problem.
