### PR TITLE
Updated command name prefix to match project name

### DIFF
--- a/keymaps/rspec.cson
+++ b/keymaps/rspec.cson
@@ -8,7 +8,9 @@
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
 '.editor':
-  'ctrl+alt+t': 'rspec:run'
-  'ctrl+alt+x': 'rspec:run-for-line'
-  'ctrl+alt+e': 'rspec:run-last'
-  'ctrl+alt+r': 'rspec:run-all'
+  'ctrl-alt-t': 'atom-rspec:run'
+  'ctrl-alt-x': 'atom-rspec:run-for-line'
+  'ctrl-alt-e': 'atom-rspec:run-last'
+
+'.workspace':
+  'ctrl-alt-r': 'atom-rspec:run-all'

--- a/lib/rspec.coffee
+++ b/lib/rspec.coffee
@@ -18,10 +18,10 @@ module.exports =
       spec_directory:        @configDefaults.spec_directory,
       force_colored_results: @configDefaults.force_colored_results
 
-    atom.workspaceView.command 'rspec:run'         , => @run()
-    atom.workspaceView.command 'rspec:run-for-line', => @runForLine()
-    atom.workspaceView.command 'rspec:run-last'    , => @runLast()
-    atom.workspaceView.command 'rspec:run-all'     , => @runAll()
+    atom.workspaceView.command 'atom-rspec:run'         , => @run()
+    atom.workspaceView.command 'atom-rspec:run-for-line', => @runForLine()
+    atom.workspaceView.command 'atom-rspec:run-last'    , => @runLast()
+    atom.workspaceView.command 'atom-rspec:run-all'     , => @runAll()
 
     atom.workspace.registerOpener (uriToOpen) ->
       {protocol, pathname} = url.parse(uriToOpen)

--- a/menus/rspec.cson
+++ b/menus/rspec.cson
@@ -1,9 +1,9 @@
 # See https://atom.io/docs/latest/creating-a-package#menus for more details
 'context-menu':
   '.overlayer':
-      'Run All Specs': 'rspec:run'
-      'Run Current Spec': 'rspec:run-for-line'
-      'Re-Run Last Spec': 'rspec:run-last'
+    'Run All Specs': 'atom-rspec:run'
+    'Run Current Spec': 'atom-rspec:run-for-line'
+    'Re-Run Last Spec': 'atom-rspec:run-last'
 
 'menu': [
   {
@@ -11,9 +11,9 @@
     'submenu': [
       'label': 'RSpec'
       'submenu': [
-        { 'label': 'Run All Specs', 'command': 'rspec:run' }
-        { 'label': 'Run Current Spec', 'command': 'rspec:run-for-line' }
-        { 'label': 'Re-Run Last Spec', 'command': 'rspec:run-last' }
+        { 'label': 'Run All Specs', 'command': 'atom-rspec:run-all' }
+        { 'label': 'Run Current Spec', 'command': 'atom-rspec:run-for-line' }
+        { 'label': 'Re-Run Last Spec', 'command': 'atom-rspec:run-last' }
       ]
     ]
   }

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "description": "Atom RSpec runner package",
   "activationEvents": [
-    "rspec:run",
-    "rspec:run-for-line",
-    "rspec:run-last",
-    "rspec:run-all"
+    "atom-rspec:run",
+    "atom-rspec:run-for-line",
+    "atom-rspec:run-last",
+    "atom-rspec:run-all"
   ],
   "repository": "https://github.com/fcoury/atom-rspec",
   "license": "MIT",


### PR DESCRIPTION
- Updated **rspec:** command prefix to **atom-rspec:** to follow Atom's convention for displaying keybindings on the Package Settings page

![Package Settings](http://i.imgur.com/c81hjY3.png)
