### PR TITLE
Fix with rbenv

### DIFF
--- a/keymaps/rspec.cson
+++ b/keymaps/rspec.cson
@@ -12,3 +12,7 @@
   'ctrl+alt+x': 'rspec:run-for-line'
   'ctrl+alt+e': 'rspec:run-last'
   'ctrl+alt+r': 'rspec:run-all'
+
+'.vim-mode.command-mode:not(.mini)':
+  ', t': 'rspec:run'
+  ', T': 'rspec:run-for-line'

--- a/lib/rspec-view.coffee
+++ b/lib/rspec-view.coffee
@@ -73,9 +73,9 @@ class RSpecView extends ScrollView
 
     spawn = ChildProcess.spawn
 
-    specCommand = atom.config.get("atom-rspec.command")
+    specCommand = atom.config.get("rspec.command")
     options = " --tty"
-    options += " --color" if atom.config.get("atom-rspec.force_colored_results")
+    options += " --color" if atom.config.get("rspec.force_colored_results")
     command = "#{specCommand} #{options} #{@filePath}"
     command = "#{command}:#{lineNumber}" if lineNumber
 

--- a/lib/rspec-view.coffee
+++ b/lib/rspec-view.coffee
@@ -81,7 +81,7 @@ class RSpecView extends ScrollView
 
     console.log "[RSpec] running: #{command}"
 
-    terminal = spawn("bash", ["-l"])
+    terminal = spawn(atom.config.get("rspec.shell"), ["-l"])
 
     terminal.on 'close', @onClose
 

--- a/lib/rspec.coffee
+++ b/lib/rspec.coffee
@@ -13,7 +13,7 @@ module.exports =
       @lastFile = state.lastFile
       @lastLine = state.lastLine
 
-    atom.config.setDefaults "atom-rspec",
+    atom.config.setDefaults "rspec",
       command:               @configDefaults.command,
       spec_directory:        @configDefaults.spec_directory,
       force_colored_results: @configDefaults.force_colored_results
@@ -77,4 +77,4 @@ module.exports =
     project = atom.project
     return unless project?
 
-    @openUriFor(project.getPath() + "/" + atom.config.get("atom-rspec.spec_directory"))
+    @openUriFor(project.getPath() + "/" + atom.config.get("rspec.spec_directory"))

--- a/lib/rspec.coffee
+++ b/lib/rspec.coffee
@@ -4,6 +4,7 @@ RSpecView = require './rspec-view'
 
 module.exports =
   configDefaults:
+    shell: 'bash'
     command: "rspec",
     spec_directory: "spec",
     force_colored_results: true,
@@ -14,6 +15,7 @@ module.exports =
       @lastLine = state.lastLine
 
     atom.config.setDefaults "rspec",
+      shell:                 @configDefaults.shell,
       command:               @configDefaults.command,
       spec_directory:        @configDefaults.spec_directory,
       force_colored_results: @configDefaults.force_colored_results


### PR DESCRIPTION
This package wasn't working for me out of the box using zsh + rbenv. I added an option to set the shell. I also found that there was a discrepancy between the options namespace being used and the package namespace, so I changed instances of `atom-rspec` to just `rspec`. Finally I added keybindings for vim-mode that match the defaults used in [rails.vim](https://github.com/tpope/vim-rails).

Let me know if you want separate PRs or need tests.