### PR TITLE
Replace output parsing order to avoid escaped links to files issue #36

### DIFF
--- a/lib/rspec-view.coffee
+++ b/lib/rspec-view.coffee
@@ -93,15 +93,16 @@ class RSpecView extends ScrollView
 
   addOutput: (output) =>
 
-    output = $('<div/>').text("#{output}").html();
-    output = output.replace /([^\s]*:[0-9]+)/g, (match) =>
-      file = match.split(":")[0]
-      line = match.split(":")[1]
-      $$$ -> @a href: file, 'data-line': line, 'data-file': file, match
+    output = "#{output}"
 
     # If running rspec in --tty mode replace the color codes
     output = output.replace /\[(3[0-7])m([^\[]*)\[0m/g, (match, colorCode, text) =>
       $$$ -> @p class: "rspec-color tty-#{colorCode}", text
+
+    output = output.replace /([^\s]*:[0-9]+)/g, (match) =>
+      file = match.split(":")[0]
+      line = match.split(":")[1]
+      $$$ -> @a href: file, 'data-line': line, 'data-file': file, match
 
     @spinner.hide()
     @output.append("#{output}")


### PR DESCRIPTION
Order matters :) This should fix #36
