### PR TITLE
fix deprecated CSS selectors in atom 1.0

### DIFF
--- a/keymaps/rspec.cson
+++ b/keymaps/rspec.cson
@@ -7,7 +7,7 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.editor':
+'.atom-text-editor':
   'ctrl+alt+t': 'rspec:run'
   'ctrl+alt+x': 'rspec:run-for-line'
   'ctrl+alt+e': 'rspec:run-last'

--- a/stylesheets/rspec.less
+++ b/stylesheets/rspec.less
@@ -24,7 +24,7 @@
 
 .rspec-console.rspec {
   pre,
-  pre div.editor,
+  pre div.atom-text-editor,
   code,
   tt {
     font-size: 12px;


### PR DESCRIPTION
The deprecation cop was raising these two deprecations:

> Use the `atom-text-editor` tag instead of the `editor` class.