### PR TITLE
Fix keymaps selector for keybindings

### DIFF
--- a/keymaps/rspec.cson
+++ b/keymaps/rspec.cson
@@ -7,7 +7,7 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.editor':
+'atom-text-editor':
   'ctrl+alt+t': 'rspec:run'
   'ctrl+alt+x': 'rspec:run-for-line'
   'ctrl+alt+e': 'rspec:run-last'

--- a/styles/rspec.less
+++ b/styles/rspec.less
@@ -24,7 +24,7 @@
 
 .rspec-console.rspec {
   pre,
-  pre div.editor,
+  pre div.atom-text-editor,
   code,
   tt {
     font-size: 12px;


### PR DESCRIPTION
Atom requires to use atom-text-editor instead or editor only.