### PR TITLE
fixed default keymaps to use correct atom pattern, ex. ctrl-alt-r rat…

### DIFF
--- a/keymaps/rspec.cson
+++ b/keymaps/rspec.cson
@@ -8,7 +8,7 @@
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
 '.editor':
-  'ctrl+alt+t': 'rspec:run'
-  'ctrl+alt+x': 'rspec:run-for-line'
-  'ctrl+alt+e': 'rspec:run-last'
-  'ctrl+alt+r': 'rspec:run-all'
+  'ctrl-alt-t': 'rspec:run'
+  'ctrl-alt-x': 'rspec:run-for-line'
+  'ctrl-alt-e': 'rspec:run-last'
+  'ctrl-alt-r': 'rspec:run-all'


### PR DESCRIPTION
…her than ctrl+alt+r

https://atom.io/docs/v0.204.0/behind-atom-keymaps-in-depth#keystroke-patterns