### PR TITLE
project.getPath() did not exist causing undefined method error, fixed.

### DIFF
--- a/lib/rspec-view.coffee
+++ b/lib/rspec-view.coffee
@@ -58,7 +58,7 @@ class RSpecView extends ScrollView
       line = $(e.target).data('line')
       file = $(e.target).data('file')
       console.log(file)
-      file = "#{atom.project.getPath()}/#{file}"
+      file = "#{atom.project.getPaths()}/#{file}"
 
       promise = atom.workspace.open(file, { searchAllPanes: true, initialLine: line })
       promise.done (editor) ->

--- a/lib/rspec-view.coffee
+++ b/lib/rspec-view.coffee
@@ -58,7 +58,7 @@ class RSpecView extends ScrollView
       line = $(e.target).data('line')
       file = $(e.target).data('file')
       console.log(file)
-      file = "#{atom.project.getPaths()}/#{file}"
+      file = "#{atom.project.getPaths()[0]}/#{file}"
 
       promise = atom.workspace.open(file, { searchAllPanes: true, initialLine: line })
       promise.done (editor) ->

--- a/lib/rspec.coffee
+++ b/lib/rspec.coffee
@@ -87,5 +87,5 @@ module.exports =
     project = atom.project
     return unless project?
 
-    @openUriFor(project.getPaths() +
+    @openUriFor(project.getPaths()[0] +
     "/" + atom.config.get("atom-rspec.spec_directory"), @lastLine)

--- a/lib/rspec.coffee
+++ b/lib/rspec.coffee
@@ -87,4 +87,5 @@ module.exports =
     project = atom.project
     return unless project?
 
-    @openUriFor(project.getPath() + "/" + atom.config.get("atom-rspec.spec_directory"))
+    @openUriFor(project.rootDirectories[0].path +
+    "/" + atom.config.get("atom-rspec.spec_directory"), @lastLine)

--- a/lib/rspec.coffee
+++ b/lib/rspec.coffee
@@ -87,5 +87,5 @@ module.exports =
     project = atom.project
     return unless project?
 
-    @openUriFor(project.rootDirectories[0].path +
+    @openUriFor(project.getPaths() +
     "/" + atom.config.get("atom-rspec.spec_directory"), @lastLine)


### PR DESCRIPTION
I'm sure there's a cleaner way to do this, but I haven't had the chance to look at much of atom-core. An improvement that implements project.getPath() as project.rootDirectories[0].path would be sweet. 