### PR TITLE
Use `then` instead of `done` for promises.

### DIFF
--- a/lib/rspec-view.coffee
+++ b/lib/rspec-view.coffee
@@ -60,7 +60,7 @@ class RSpecView extends ScrollView
       file = "#{atom.project.getPaths()[0]}/#{file}"
 
       promise = atom.workspace.open(file, { searchAllPanes: true, initialLine: line })
-      promise.done (editor) ->
+      promise.then (editor) ->
         editor.setCursorBufferPosition([line-1, 0])
 
   run: (lineNumber) ->

--- a/lib/rspec.coffee
+++ b/lib/rspec.coffee
@@ -60,7 +60,7 @@ module.exports =
 
     previousActivePane = atom.workspace.getActivePane()
     uri = "rspec-output://#{file}"
-    atom.workspace.open(uri, split: 'right', activatePane: false, searchAllPanes: true).done (rspecView) ->
+    atom.workspace.open(uri, split: 'right', activatePane: false, searchAllPanes: true).then (rspecView) ->
       if rspecView instanceof RSpecView
         rspecView.run(lineNumber)
         previousActivePane.activate()


### PR DESCRIPTION
It seems than in Atom 1.1.0, `Promise.done` does not exist anymore.
I changed it to `Promise.then` to avoid the plugin to crash.
