### PR TITLE
Add window position option to run specs

### DIFF
--- a/lib/rspec.coffee
+++ b/lib/rspec.coffee
@@ -16,6 +16,9 @@ module.exports =
     force_colored_results:
       type: 'boolean'
       default: true
+    window_split:
+      type: 'string'
+      default: 'right'
 
   rspecView: null
   subscriptions: null
@@ -60,7 +63,8 @@ module.exports =
 
     previousActivePane = atom.workspace.getActivePane()
     uri = "rspec-output://#{file}"
-    atom.workspace.open(uri, split: 'right', activatePane: false, searchAllPanes: true).done (rspecView) ->
+    window_split = atom.config.get("rspec.window_split")
+    atom.workspace.open(uri, split: window_split, activatePane: false, searchAllPanes: true).done (rspecView) ->
       if rspecView instanceof RSpecView
         rspecView.run(lineNumber)
         previousActivePane.activate()

--- a/lib/rspec.coffee
+++ b/lib/rspec.coffee
@@ -19,6 +19,7 @@ module.exports =
     window_split:
       type: 'string'
       default: 'right'
+      enum: ['left', 'right', 'up', 'down']
 
   rspecView: null
   subscriptions: null


### PR DESCRIPTION
Let users to config where the spec window is loaded, keep default to right
