### PR TITLE
added hotkey to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Add ability to run RSpec and see the output without leaving Atom.
 
 HotKeys:
 
+- __Ctrl+Alt+R__ - executes all specs
 - __Ctrl+Alt+T__ - executes all specs the current file
 - __Ctrl+Alt+X__ - executes only the spec on the line the cursor's at
 - __Ctrl+Alt+E__ - re-executes the last executed spec


### PR DESCRIPTION
For some reason the README did not state there is a (well needed) hotkey to run all tests at once, no matter which file the user currently browses.
Found the hotkey after digging through the keymaps, but this way it's actually far easier for the user to get the information..