### PR TITLE
upgrade copy listener to Atom 1.0 api

### DIFF
--- a/lib/rspec-view.coffee
+++ b/lib/rspec-view.coffee
@@ -16,7 +16,9 @@ class RSpecView extends ScrollView
 
   initialize: ->
     super
-    @on 'core:copy': => @copySelectedText()
+    rspec = this
+    atom.commands.add 'atom-workspace','core:copy': (event) ->
+      rspec.copySelectedText()
 
   constructor: (filePath) ->
     super


### PR DESCRIPTION
This pull request upgrades the "core:copy" listener to atom 1.0 api
more info [here](http://flight-manual.atom.io/upgrading-to-1-0-apis/sections/upgrading-your-package/)