### PR TITLE
create an option to configure the pane split direction

### DIFF
--- a/lib/rspec.coffee
+++ b/lib/rspec.coffee
@@ -16,6 +16,17 @@ module.exports =
     force_colored_results:
       type: 'boolean'
       default: true
+    split:
+      type: 'string'
+      default: 'right'
+      description: 'The direction in which to split the pane when launching rspec'
+      enum: [
+        {value: 'right', description: 'Right'}
+        {value: 'left', description: 'Left'}
+        {value: 'up', description: 'Up'}
+        {value: 'down', description: 'Down'}
+      ]
+
 
   rspecView: null
   subscriptions: null
@@ -61,7 +72,7 @@ module.exports =
 
     previousActivePane = atom.workspace.getActivePane()
     uri = "rspec-output://#{file}"
-    atom.workspace.open(uri, split: 'right', activatePane: false, searchAllPanes: true).then (rspecView) ->
+    atom.workspace.open(uri, split: atom.config.get("rspec.split"), activatePane: false, searchAllPanes: true).then (rspecView) ->
       if rspecView instanceof RSpecView
         rspecView.run(lineNumber)
         previousActivePane.activate()


### PR DESCRIPTION
It bugged me that a new rspec pane was always opening on the right.  In my configuration and workflow for Atom, it makes more sense to split the pane down.  So I added this as an option.  The default is still the "split right" behavior.